### PR TITLE
ルーレット画像の処理変更

### DIFF
--- a/css/fortune.css
+++ b/css/fortune.css
@@ -163,3 +163,30 @@
   grid-column: 2 / 3;
 }
 
+
+
+/* -------------------
+ * ルーレット画像を設定するためのスタイル
+ ------------------- */
+.omikuji-image{
+  /* 画像をabsoluteで配置するためにrelativeにしておく */
+position: relative;
+}
+
+/* absoluteで真ん中配置（画像切り替え用にz方向に重ねておく） */
+.omikuji-image>.image {
+  position: absolute;
+  left:0;
+  right:0;
+}
+
+/* デフォルトではルーレット画像非表示で、選ばれたら表示 */
+.omikuji-image>.image.image-roulette{
+  visibility: hidden;
+}
+.omikuji-image>.image.image-roulette.selected{
+  visibility: visible;
+}
+/* -------------------
+ * ルーレット画像を設定するためのスタイル ここまで
+ ------------------- */

--- a/js/fortune.js
+++ b/js/fortune.js
@@ -109,3 +109,37 @@ const setteiHomeImage = (image) => {
   // タイトル画面の画像を設定
   omikujiImage.src = `img/${image}`;
 }
+
+
+//ルーレット画像のDOM
+let rouletteImages = [];
+
+//ルーレット画像を隠す
+const kakusuRoulette = () => {
+	for(let i=0; i<omikujiRoulette.length; i++){
+		rouletteImages[i].classList.remove('selected');
+	}
+};
+
+// ルーレット画像が設定されている場合、visibility: hiddenで画像要素を作成しておく
+document.addEventListener('DOMContentLoaded', function() {
+    //ルーレット画像が設定されている場合
+	if(omikujiRoulette != null && Array.isArray(omikujiRoulette)){
+		for(let i=0; i<omikujiRoulette.length; i++){
+			let img_wrapper = document.getElementsByClassName('omikuji-image')[0];
+			//ルーレット画像要素の作成
+			let img = document.createElement('img');
+			img.src = `img/${omikujiRoulette[i]}`;
+			img.classList.add('image');
+			img.classList.add('image-roulette');
+
+			//ルーレット画像の親要素に画像要素を追加
+			img_wrapper.appendChild(img);
+
+		}
+
+		//グローバル変数にセットしておく
+		rouletteImages = document.getElementsByClassName('image-roulette');;
+
+	}
+});

--- a/step3/app.js
+++ b/step3/app.js
@@ -105,6 +105,9 @@ let hikuOmikuji = () => {
     // ルーレットのタイマーを止める
     tomeruTimer(rouletteTimer);
 
+      //ルーレット画像を隠す
+      kakusuRoulette();
+
     // おみくじの結果を見せる
     miseruOmikujiKekka();
 


### PR DESCRIPTION
先日PCであったように、ルーレット画像でsrcの書き換えだとキャンセルされる場合があるようです。

ルーレット画像を予めDOMに作成しておき、ルーレット回したときはそのDOMの表示非表示を切り替えるように修正しました。

子供たちの現状に影響でないように検討したんですが、Step#3まで終わっている子には、ルーレット画像を結果表示前に非表示にする処理を1行追加する必要があります。
```
matsuTimer(()=>{
（中略）
                //ルーレット画像を隠す
		kakusuRoulette();
（中略）
```

※厳密にいうと、`kakusuRoulette();`を`setteiKekkaTitle`の中で呼べば、app.jsをいじらずに、fortune.jsのupdateだけで行けるんですが、ちょっと気持ち悪いかなと思いました。